### PR TITLE
chore(dependencies): migrate dependencies from dependencies block to peerDependencies and devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,15 +40,13 @@
   "bugs": {
     "url": "https://github.com/katungi/expo-azure-blob-storage/issues"
   },
-  "dependencies": {
-    "expo-constants": ">=17.0.0",
-    "expo-file-system": ">=15.0.0",
-    "expo-image-picker": "^16.1.4"
-  },
   "peerDependencies": {
     "expo": ">=49.0.0",
     "react": ">=18.0.0",
-    "react-native": ">=0.70.0"
+    "react-native": ">=0.70.0",
+    "expo-constants": ">=17.0.0",
+    "expo-file-system": ">=15.0.0",
+    "expo-image-picker": "^16.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -58,7 +56,10 @@
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-native": "0.79.5",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "expo-constants": ">=17.0.0",
+    "expo-file-system": ">=15.0.0",
+    "expo-image-picker": "^16.1.4"
   },
   "files": [
     "lib",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,16 @@ settings:
 importers:
 
   .:
-    dependencies:
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.25.2
+        version: 7.28.0
+      '@types/node':
+        specifier: ^18.0.0
+        version: 18.19.115
+      '@types/react':
+        specifier: ~19.0.10
+        version: 19.0.14
       expo:
         specifier: ~53.0.16
         version: 53.0.16(@babel/core@7.28.0)(react-native@0.79.5(@babel/core@7.28.0)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -29,16 +38,6 @@ importers:
       react-native:
         specifier: 0.79.5
         version: 0.79.5(@babel/core@7.28.0)(@types/react@19.0.14)(react@19.0.0)
-    devDependencies:
-      '@babel/core':
-        specifier: ^7.25.2
-        version: 7.28.0
-      '@types/node':
-        specifier: ^18.0.0
-        version: 18.19.115
-      '@types/react':
-        specifier: ~19.0.10
-        version: 19.0.14
       typescript:
         specifier: ~5.8.3
         version: 5.8.3


### PR DESCRIPTION
This pull request migrates all the dependencies found in the dependencies block to the peerDependencies and devDependencies blocks. Previously, in the README, we tell the developer to install three dependencies namely: `expo-file-system`, `expo-image-picker` and `expo-constants` while at the same time our package has those dependencies which get bundled when building our package. By moving the dependencies into peerDependencies and devDependencies we:

1. Reduce our package's bundle size.
2. Our package works with any Expo SDK version as long as the dependencies we rely on support that version and so we do not pin a specific version in our package.
3. Aligns with the README installation guide. 
4. Our local test environment works seamlessly for debugging or testing purposes.